### PR TITLE
FEATURE: Add option for dark mode support

### DIFF
--- a/about.json
+++ b/about.json
@@ -47,6 +47,7 @@
     "far": "/assets/far.css",
     "foundation": "/assets/foundation.css",
     "github-gist": "/assets/github-gist.css",
+    "github-dark": "/assets/github-dark.css",
     "github": "/assets/github.css",
     "gml": "/assets/gml.css",
     "googlecode": "/assets/googlecode.css",

--- a/assets/github-dark.css
+++ b/assets/github-dark.css
@@ -1,0 +1,128 @@
+/*!
+  Note: Github background color modified
+
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+
+*/
+
+.hljs {
+  color: #c9d1d9;
+  background: #161b22;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60;
+}
+
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
+  font-style: italic;
+}
+
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}

--- a/javascripts/discourse/initializers/initialize-for-hljs-theme-picker.js.es6
+++ b/javascripts/discourse/initializers/initialize-for-hljs-theme-picker.js.es6
@@ -22,12 +22,22 @@ export default {
           darkSchemeName = darkSchemeName.replace("github", "github-dark");
 
           const darkPath = settings.theme_uploads[darkSchemeName];
+
           if (darkPath) {
             const linkDark = document.createElement("link");
             linkDark.setAttribute("rel", "stylesheet");
             linkDark.setAttribute("type", "text/css");
             linkDark.setAttribute("href", darkPath);
-            linkDark.setAttribute("media", "(prefers-color-scheme: dark)");
+
+            // if default scheme is dark, don't add the media query limitation
+            // i.e. use dark alternative instead
+            const schemeType = getComputedStyle(document.body).getPropertyValue(
+              "--scheme-type"
+            );
+
+            if (schemeType.trim() !== "dark") {
+              linkDark.setAttribute("media", "(prefers-color-scheme: dark)");
+            }
             document.head.appendChild(linkDark);
           }
         }

--- a/javascripts/discourse/initializers/initialize-for-hljs-theme-picker.js.es6
+++ b/javascripts/discourse/initializers/initialize-for-hljs-theme-picker.js.es6
@@ -3,7 +3,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 export default {
   name: "hljs-theme-picker",
   initialize() {
-    withPluginApi("0.8.7", api => {
+    withPluginApi("0.8.7", (api) => {
       try {
         const theme = settings.hljs_theme;
         const path = settings.theme_uploads[theme];
@@ -12,6 +12,25 @@ export default {
         link.setAttribute("type", "text/css");
         link.setAttribute("href", path);
         document.head.appendChild(link);
+
+        if (
+          settings.hljs_dark_match &&
+          (theme.endsWith("-light") || theme.endsWith("github"))
+        ) {
+          let darkSchemeName = theme.replace("-light", "-dark");
+          // special case for github because default theme is named just "github"
+          darkSchemeName = darkSchemeName.replace("github", "github-dark");
+
+          const darkPath = settings.theme_uploads[darkSchemeName];
+          if (darkPath) {
+            const linkDark = document.createElement("link");
+            linkDark.setAttribute("rel", "stylesheet");
+            linkDark.setAttribute("type", "text/css");
+            linkDark.setAttribute("href", darkPath);
+            linkDark.setAttribute("media", "(prefers-color-scheme: dark)");
+            document.head.appendChild(linkDark);
+          }
+        }
       } catch (error) {
         console.error(error);
         console.error(
@@ -19,5 +38,5 @@ export default {
         );
       }
     });
-  }
+  },
 };

--- a/settings.yml
+++ b/settings.yml
@@ -45,6 +45,7 @@ hljs_theme:
     - far
     - foundation
     - github-gist
+    - github-dark
     - github
     - gml
     - googlecode
@@ -93,3 +94,6 @@ hljs_theme:
     - xcode
     - xt256
     - zenburn
+hljs_dark_match:
+  default: false
+  description: "Load dark color scheme if available"


### PR DESCRIPTION
Adds a (default off) option to enable automatically switching to the equivalent styles when using dark mode. For example, if the selected scheme is "Solarized Light" or "Github" and the new option is checked, sites using automatic dark mode switching will default to using "Solarized Dark" or "Github Dark", respectively. 