### PR TITLE
DEV: Move settings descriptions to locales/en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,6 @@
 en:
   theme_metadata:
     description: This theme component allows you to change the highlight colors used in code blocks
+    settings:
+      hljs_theme: "Select the theme you want code blocks to use. You can visit <a target='_blank' href='https://highlightjs.org/static/demo/'>the hljs demo page</a> to preview the themes"
+      hljs_dark_match: "Load dark color scheme if available"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,5 +2,5 @@ en:
   theme_metadata:
     description: This theme component allows you to change the highlight colors used in code blocks
     settings:
-      hljs_theme: "Select the theme you want code blocks to use. You can visit <a target='_blank' href='https://highlightjs.org/static/demo/'>the hljs demo page</a> to preview the themes"
+      hljs_theme: "Select the theme you want code blocks to use. You can visit <a target='_blank' href='https://highlightjs.org/demo/'>the hljs demo page</a> to preview the themes"
       hljs_dark_match: "Load dark color palette if available"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,4 +3,4 @@ en:
     description: This theme component allows you to change the highlight colors used in code blocks
     settings:
       hljs_theme: "Select the theme you want code blocks to use. You can visit <a target='_blank' href='https://highlightjs.org/static/demo/'>the hljs demo page</a> to preview the themes"
-      hljs_dark_match: "Load dark color scheme if available"
+      hljs_dark_match: "Load dark color palette if available"

--- a/settings.yml
+++ b/settings.yml
@@ -1,5 +1,4 @@
 hljs_theme:
-  description: "Select the theme you want code blocks to use. You can visit <a target='_blank' href='https://highlightjs.org/static/demo/'>the hljs demo page</a> to preview the themes"
   default: github
   type: enum
   choices:
@@ -77,4 +76,3 @@ hljs_theme:
     - xt256
 hljs_dark_match:
   default: false
-  description: "Load dark color scheme if available"


### PR DESCRIPTION
This change enables the translation of setting descriptions via Crowdin

Additionally:

* The term "color scheme" has been updated to "color palette" to pass the tests.

* The link to the Highlight.js demo has been updated to match the change made in https://github.com/discourse/discourse/pull/29701.